### PR TITLE
configure API base URL for dev and prod

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:5002

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0-beta.4",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build --mode production",
     "start": "vite preview --port 5173 --host 0.0.0.0",
     "test": "vitest",
     "clean": "prettier --write src",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,5 +1,6 @@
 // Backend API configuration
-export const API_BASE_URL = '';
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
 
 // API endpoints
 export const API_ENDPOINTS = {

--- a/start.sh
+++ b/start.sh
@@ -42,5 +42,4 @@ fi
 # Start the frontend development server
 echo "Starting frontend server..."
 cd ../..
-npm run build
-npm start
+npm run dev

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -46,16 +46,15 @@ export default defineConfig({
     port: process.env.PORT ? parseInt(process.env.PORT) : 5173,
     allowedHosts: ["deepgit.onrender.com"]
   },
-  // Disable automatic public directory copying
-  publicDir: false,
-  // Manually copy only specific files from public
+  // Only disable public directory copying during build
+  publicDir: process.env.NODE_ENV === 'production' ? false : 'public',
   build: {
     rollupOptions: {
       input: {
         main: resolve(__dirname, 'index.html'),
       },
     },
-    // Copy only specific files from public
+    // Copy only specific files from public during build
     copyPublicDir: true,
     assetsInlineLimit: 0,
   },


### PR DESCRIPTION
Set up environment-specific config using `.env.development` and `.env.production`. Refactored `API_BASE_URL` to use `import.meta.env.VITE_API_BASE_URL`.









